### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/server-side/src/controllers/user.controller.js
+++ b/server-side/src/controllers/user.controller.js
@@ -108,7 +108,7 @@ const changeIMG = asyncWrapper(async (req, res, next) => {
 const changePassword = asyncWrapper(async (req, res, next) => {
   const userId = req.user._id;
   const { password } = req.body;
-  console.log(password, userId);
+  console.log(`Password change request received for user: ${userId}`);
   if (!password) {
     return next(new AppError("Password is required", 400, httpStatusText.FAIL));
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/2](https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/2)

To fix the problem, we need to remove the logging of sensitive information, specifically the password, from the console log statement. Instead of logging the password, we can log a message indicating that a password change request was received without exposing the actual password.

- Remove the console log statement that logs the password.
- Optionally, replace it with a log statement that does not include sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
