### PR TITLE
Potential fix for code scanning alert no. 49: Database query built from user-controlled sources

### DIFF
--- a/server-side/src/controllers/registration.controller.js
+++ b/server-side/src/controllers/registration.controller.js
@@ -165,7 +165,7 @@ const transporter = nodemailer.createTransport({
 
 const forgotPassword = asyncWrapper(async (req, res, next) => {
   const { email } = req.body;
-  let user = await userModel.findOne({ email });
+  let user = await userModel.findOne({ email: { $eq: email } });
   if (!user) {
     return next(
       new AppError(


### PR DESCRIPTION
Potential fix for [https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/49](https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/49)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `email` value is treated as a literal string and not as a potential query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
