### PR TITLE
Potential fix for code scanning alert no. 48: Database query built from user-controlled sources

### DIFF
--- a/server-side/src/controllers/registration.controller.js
+++ b/server-side/src/controllers/registration.controller.js
@@ -50,7 +50,7 @@ const signup = asyncWrapper(async (req, res, next) => {
 const login = asyncWrapper(async (req, res, next) => {
   const user = req.body;
   let foundedUser = await userModel.findOne({
-    email: user.email,
+    email: { $eq: user.email },
   });
   if (!foundedUser) {
     return next(


### PR DESCRIPTION
Potential fix for [https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/48](https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/48)

To fix the problem, we need to ensure that the `user.email` value is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the value is interpreted as a literal rather than a query object. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
