### PR TITLE
Potential fix for code scanning alert no. 50: Database query built from user-controlled sources

### DIFF
--- a/server-side/src/controllers/registration.controller.js
+++ b/server-side/src/controllers/registration.controller.js
@@ -206,7 +206,7 @@ const forgotPassword = asyncWrapper(async (req, res, next) => {
 });
 const resetPassword = asyncWrapper(async (req, res, next) => {
   const { token, password } = req.body;
-  let user = await userModel.findOne({ resetToken: token });
+  let user = await userModel.findOne({ resetToken: { $eq: token } });
   if (!user || user.resetTokenExpiry < Date.now()) {
     return next(
       new AppError("Invalid or expired token.", 400, httpStatusText.FAIL)


### PR DESCRIPTION
Potential fix for [https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/50](https://github.com/Kamilia98/Furniture-ecommerce/security/code-scanning/50)

To fix the problem, we need to ensure that the user-provided `token` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the `token` is interpreted as a literal value and not as a query object. This change will prevent NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
